### PR TITLE
EDIT - 모바일 상품 상세페이지 리뷰 풀커스텀 적용

### DIFF
--- a/assets/stylesheets/mobile/pinkage.css.scss
+++ b/assets/stylesheets/mobile/pinkage.css.scss
@@ -1,4 +1,5 @@
 @import "compass/css3/border-radius";
+@import "compass/css3/transition";
 
 .gallery--no_padding {
   padding: 0;
@@ -41,4 +42,214 @@
 
 .gallery-item.review-gallery-item .section.section-review.section-review--no_border {
   border-bottom: 0;
+}
+
+// Product reviews
+body.products.reviews.widget_style_list {
+  #topbar {
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
+    background: #1b1b1b;
+
+    ul {
+      position: absolute;
+      top: 12px;
+      left: 18px;
+      height: 20px;
+    }
+  }
+}
+
+.products_reviews_topbar__back_button {
+  color: white;
+}
+
+.products_reviews__head {
+  margin-bottom: 12px;
+}
+
+.products_reviews__reviews_new_link {
+  @include border-radius(24px);
+  text-align: center;
+  border: 1px solid #1b1b1b;
+  margin: 0 16px;
+  font-size: 16px;
+  color: black;
+  line-height: 42px;
+}
+
+
+.products_reviews_topbar__product_info_container {
+  text-align: center;
+  line-height: 42px;
+}
+
+.products_reviews_topbar__product_info {
+  display: inline-block;
+}
+
+.products_reviews_topbar__product_info--ml {
+  margin-left: 15px;
+}
+
+.products_reviews_topbar__info_title {
+  color: #fffefe;
+}
+
+.products_reviews_topbar__info_value {
+  color: #efbbbb;
+}
+
+li.review.review_list--pinkage {
+  border-bottom: 1px solid #e1e0e1;
+  margin: 0;
+  padding: 0 4px;
+}
+
+.review_list__message--no_padding {
+  padding: 0;
+}
+
+.review_list__content_section--padding {
+  padding: 0 12px;
+}
+
+.review_score__author_name {
+  display: inline-block;
+  font-weight: bold;
+  color: #2e2e2e;
+  margin-right: 8px;
+}
+
+.review_score__created_at {
+  padding: 0 14px;
+  color: #9c9c9c;
+}
+
+.review_list__see_more--pinkage {
+  color: #262626;
+  font-weight: bold;
+}
+
+.review_list__collapse_link_container {
+  display: none;
+  text-align: center;
+}
+
+.review_list__collapse_link_icon {
+  width: 22px;
+  height: 10px;
+}
+
+.review_list--expanded {
+  .review_list__collapse_link_container {
+    display: block;
+    padding-bottom: 13px;
+  }
+}
+
+.review-options--pinkage {
+  margin-top: 0;
+}
+
+.review_like_action__comments_count {
+  margin-left: 8px;
+}
+
+.review_list__comments_icon {
+  position: absolute;
+  right: 13px;
+  top: 0;
+  text-align: center;
+  height: 47px;
+  vertical-align: middle;
+  line-height: 47px;
+  background-color: white;
+  box-sizing: content-box;
+}
+
+.review_link_action__like_button {
+  font-size: 20px;
+  display: inline-block;
+  text-align: center;
+  color: #878787;
+  vertical-align: middle;
+  @include transition(all 0.4s ease);
+}
+
+.review_like_action .likable {
+  position: absolute;
+  top: 1px;
+  right: -20px;
+  bottom: 0;
+  font-size: 0;
+}
+
+.review_link_action__like_icon {
+  display: block;
+}
+
+.review_link_action__liked_icon {
+  display: none;
+}
+
+.review_list__like_action .liked {
+  .review_link_action__like_icon {
+    display: none;
+  }
+
+  .review_link_action__liked_icon {
+    display: block;
+    color: #a33e3a;
+  }
+}
+
+.review_list_comment__author_name {
+  font-weight: bold;
+}
+
+.review_list__comment_section {
+  font-size: 12px;
+}
+
+.frame__sub_frame:first-child.review_list__comment_section {
+  border-top: 1px solid #cccccc;
+}
+
+.review_list__new_comment_section {
+  border: 1px solid #cccccc;
+  margin: 0 10px 17px 10px;
+}
+
+.review_list_comment__message {
+  margin-right: 45px;
+}
+
+.review_list_comment__date {
+  position: absolute;
+  top: 10px;
+  right: 8px;
+  color: #a5a5a5;
+}
+
+.new-comments--pinkage {
+  padding: 0px 65px 0px 12px;
+  line-height: 39px;
+}
+
+.review_list_comment__new_comment_button {
+  width: 40px;
+  height: 39px;
+  background: white;
+  color: #878787;
+  margin: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  font-size: 12px;
+}
+
+.review_list__comment_section .comment {
+  border-top: none;
 }

--- a/views/mobile/products/reviews/_list.html.erb
+++ b/views/mobile/products/reviews/_list.html.erb
@@ -1,0 +1,63 @@
+<% title t('reviews.product_reviews') %>
+<% content_for :topbar do %>
+  <div>
+    <ul class="products_reviews_topbar__back_button">
+      <%= content_tag :li, class: 'action close' do %>
+        <%= content_tag(
+          :a,
+          class: 'link-close topbar_link_close',
+          data: {
+            in_progress_confirm: t('topbar.in_progress_confirm')
+          }
+        ) do %>
+          <span class="topbar_link_close__close">
+            <i class="fa fa-chevron-left"></i>
+          </span>
+          <span class="topbar_link_close__back">
+            <i class="fa fa-chevron-left"></i>
+          </span>
+        <% end %>
+      <% end %>
+    </ul>
+    <div class="products_reviews_topbar__product_info_container">
+      <div class="products_reviews_topbar__product_info">
+        <span class="products_reviews_topbar__info_title">전체 리뷰</span>
+        <span class="products_reviews_topbar__info_value"><%= photo ? product.meta_visible_reviews.with_photo.count : product.meta_visible_reviews.count %></span>
+      </div>
+      <div class="products_reviews_topbar__product_info products_reviews_topbar__product_info--ml">
+        <span class="products_reviews_topbar__info_title">고객 만족도</span>
+        <span class="products_reviews_topbar__info_value"><%= product.display_score('-') %></span>
+      </div>
+    </div>
+  </div>
+<% end %>
+<% content_for :content do %>
+  <% if @product %>
+    <%= content_tag :div, class: "panel panel-reviews pagination-list panel-reviews--product #{'no-data' if @reviews.total_count == 0}" do %>
+      <div class="products_reviews__head">
+        <%= link_to new_mobile_review_path(review_source: @review_source) do %>
+          <div class="products_reviews__reviews_new_link">리뷰 작성하기</div>
+        <% end %>
+      </div>
+      <% if widget.gallery? %>
+        <%= render 'reviews/reviews_gallery' %>
+      <% else %>
+        <div class="panel-body page">
+          <% if @reviews.empty? %>
+            <ul class="reviews">
+              <%= render 'common/reviews/no_reviews' %>
+            </ul>
+          <% else %>
+            <ul class="reviews">
+              <%= widget.render_reviews(self, @reviews) %>
+            </ul>
+          <% end %>
+        </div>
+        <div class="panel-footer">
+          <%= render 'common/shared/pagination', resources: @reviews %>
+        </div>
+      <% end %>
+    <% end %>
+  <% end %>
+  <%= content_tag :div, nil, data: {url: url_for(params.merge(category_id: @category.try(:id), group: ReviewGroupBy::NONE, sort: @review_sort))}, id: 'data-sort-type', class: 'hidden' %>
+<% end %>

--- a/views/mobile/products/reviews/list/_review.html.erb
+++ b/views/mobile/products/reviews/list/_review.html.erb
@@ -1,0 +1,124 @@
+<%
+hide_image = false if !local_assigns[:hide_image]
+display_user_grade = @brand.review_author_display_type == ReviewAuthorDisplayType::USER_GRADE && @brand.brand_user_grade_display_format_in_reviews_index.present?
+
+review_list_status = widget.message_initial_rows == ReviewInitialRows::ALL ? :expanded : :collapsed
+if widget.review_message_all_collapsed?
+  collapsed_message = widget.collapsed_title
+  collapsed_message_style = nil
+else
+  collapsed_message = review.message_with_prefix.html
+  message_initial_rows = widget.message_initial_rows == 0 ? 3 : widget.message_initial_rows
+  collapsed_message_style = "max-height: #{message_initial_rows * 18}px"
+end
+%>
+<%= content_tag_for(
+  :li,
+  review,
+  class: "review_list review_list--#{review_list_status} review_list--pinkage",
+  data: {message_initial_rows: widget.message_initial_rows}
+) do %>
+  <% if brand.review_show_score && review.score %>
+    <%= content_tag :div, class: "review_score" do %>
+      <div class="review_score__author_name"><%= review.user_display_name %></div>
+      <div class="review_score__star_rating">
+        <%= render 'reviews/star_rating', score: review.score %>
+      </div>
+      <div class="review_score__right">
+        <div class="review_score__right_item review_score__created_at"><%= review.created_at.strftime("%Y.%m.%d") %></div>
+        <%= link_to(
+          t('reviews.edit_review'),
+          edit_mobile_review_path(review),
+          data: {link_target: 'window'},
+          class: 'review_score__right_item review_score__edit'
+        ) if review.editable?(current_user) %>
+      </div>
+    <% end %>
+  <% end %>
+  <div class="review_list__content_section review_list__content_section--padding">
+    <%= render('reviews/list/product', review: review) if widget.widget_type == WidgetType::REVIEWS %>
+    <div class="review_list__content_wrap">
+      <div class="review_list__content review_list__content--collapsed">
+        <a class="review_list__content_link review_list__expand_link">
+          <%= content_tag :div, class: 'review_list__message review_list__message--no_padding', style: collapsed_message_style do %>
+            <%= collapsed_message %>
+          <% end %>
+          <%= content_tag(
+            :div,
+            "...#{t('reviews.see_more_simple')}",
+            class: 'review_list__see_more review_list__see_more--pinkage'
+          ) %>
+        </a>
+        <% if review.photo? %>
+          <% if widget.show_image_when_collapsed %>
+            <%= render 'reviews/list/images', review: review %>
+          <% else %>
+            <%= content_tag(
+              :div,
+              t('reviews.images_count', count: review.images_count),
+              class: 'review_list__images_count'
+            ) %>
+          <% end %>
+        <% end %>
+      </div>
+      <div class="review_list__content review_list__content--expanded">
+        <%= render 'reviews/options', review: review, klass: 'review_list__options review-options--pinkage' %>
+        <div class="review_list__message">
+          <%= render 'reviews/message', review: review %>
+        </div>
+        <%= render 'reviews/list/images', review: review %>
+      </div>
+    </div>
+
+    <%= render 'reviews/tag', review: review %>
+  </div>
+
+  <div class="review_list__like_section">
+    <div class="review_list__like_action">
+      <%
+      likes = likes?(review)
+      like = get_like(review)
+      %>
+      <div class="review_like_action">
+        <%= content_tag :div, class: "like-action #{(like.score > 0 ? 'liked' : 'unliked') if likes}", data: {url: like_mobile_review_path(review)} do %>
+          <div class="review_like_action__label">
+            <span>좋아요 <%= review.total_score %>개</span>
+            <span class="review_like_action__comments_count">댓글 <%= review.comments_count %>개</span>
+          </div>
+          <div class="likable">
+            <a class="link-like review_link_action__like_button">
+              <i class="fa fa-heart-o review_link_action__like_icon"></i>
+              <i class="fa fa-heart review_link_action__liked_icon"></i>
+            </a>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div class="review_list__comments_icon">
+      <% comments_tab_content = capture do %>
+        <%= image_tag(manual_asset_url('widgets/comment.png'), class: 'review_list__comments_tab_icon') %>
+      <% end %>
+
+      <% if brand.review_enable_user_comments || review.comments_count > 0 %>
+        <%= content_tag(
+          :button,
+          class: 'review_list__comments_tab_expand_button',
+          data: {url: expand_comments_mobile_review_path(review)}
+        ) do %>
+          <%= comments_tab_content %>
+        <% end %>
+      <% else %>
+        <%= comments_tab_content %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="review_list__comments comment-container">
+  </div>
+
+  <div class="review_list__collapse_link_container">
+    <a class="review_list__collapse_link">
+      <%= image_tag manual_asset_url('widgets/collapse.png'), class: 'review_list__collapse_link_icon' %>
+    </a>
+  </div>
+<% end %>

--- a/views/mobile/reviews/list/_comment.html.erb
+++ b/views/mobile/reviews/list/_comment.html.erb
@@ -1,0 +1,9 @@
+<%= content_tag_for :li, comment, class: 'review_list_comment' do %>
+  <div>
+    <div class="review_list_comment__message_container">
+      <span class="review_list_comment__author_name"><%= comment.user_display_name %></span>
+      <span class="review_list_comment__message"><%= comment.message.html %></span>
+    </div>
+    <div class="review_list_comment__date"><%= comment.created_at.strftime('%m.%d') %></div>
+  </div>
+<% end %>

--- a/views/mobile/reviews/list/_comments.html.erb
+++ b/views/mobile/reviews/list/_comments.html.erb
@@ -1,0 +1,11 @@
+<div class="frame__sub_frame review_list__comment_section">
+  <ul>
+    <%= render partial: 'reviews/list/comment', collection: review.comments %>
+  </ul>
+</div>
+
+<% if brand.review_enable_user_comments %>
+  <div class="frame__sub_frame review_list__new_comment_section">
+    <%= render 'reviews/list/new_comments', review: review %>
+  </div>
+<% end %>

--- a/views/mobile/reviews/list/_new_comments.html.erb
+++ b/views/mobile/reviews/list/_new_comments.html.erb
@@ -1,0 +1,19 @@
+<div class="new-comments new-comments--pinkage">
+  <%= form_for Comment.new, url: mobile_comments_path, validate: true, remote: true, data: {login_required: true} do |f| %>
+    <% placeholder_text = t('reviews.comments.please_write_comments') %>
+    <% if browser.iphone? %>
+      <%= content_tag :a, placeholder_text, class: 'new-comments__input new-comments__input--button', data: {login_required: true} %>
+      <%= f.hidden_field :message %>
+    <% else %>
+      <%= f.text_field :message, placeholder: placeholder_text, class: 'input-block new-comments__input', data: {login_required: true} %>
+    <% end %>
+    <%= f.hidden_field :review_id, value: review.id %>
+    <%= content_tag :button, 'OK', class: 'review_list_comment__new_comment_button' %>
+    <input type="hidden" name="tracking_id">
+    <% if current_user %>
+      <script class="blueprint" type="text/x-jquery-tmpl">
+        <%= render "comments/comment", comment: Comment.template(current_user, review) %>
+      </script>
+    <% end %>
+  <% end %>
+</div>


### PR DESCRIPTION
### 작업내용
- 기존 상단 탑바 제거하고 풀커스텀 디자인으로 적용
- 리뷰 작성하기 버튼 추가
- 리스트 영역 CSS 수정
- 리뷰 평점 영역에 작성자명과 작성일 추가하고 기존 “평점” 글씨와 평점 텍스트 제거
- 기존 작성자명, 작성일, 펼침 버튼이 있는 영역 제거
- 더보기 누르면 리뷰 영역 하단에 접기 버튼 나오도록 추가
- 리뷰 좋아요 관련 정보 나오는 영역 풀커스텀 스타일로 수정
- 좋아요 누르면 하트 아이콘이 활성화되도록 수정
- 댓글 영역 리스트 레이아웃 수정
- 댓글 입력 폼 레이아웃 수정

https://app.asana.com/0/6477641678483/328195358679419