### PR TITLE
EDIT - PC 상품 리뷰 리스트 포토썸네일 풀커스텀 적용

### DIFF
--- a/assets/stylesheets/pc/app/products/reviews/photo_thumbnail_box.css.scss
+++ b/assets/stylesheets/pc/app/products/reviews/photo_thumbnail_box.css.scss
@@ -24,15 +24,15 @@
   }
 }
 
-.photo_thumbnail_box {
-  border: 0;
-}
-
 .products_reviews_photo_thumbnail__summary {
   display: none;
 }
 
 // 풀커스텀을 적용하려는 위젯에 커스텀 CSS로 넣을 것.
+// .photo_thumbnail_box {
+//   border: 0;
+// }
+
 // .products_reviews_photo_thumbnail__summary {
 //   display: block;
 //   text-align: center;

--- a/assets/stylesheets/pc/app/products/reviews/photo_thumbnail_box.css.scss
+++ b/assets/stylesheets/pc/app/products/reviews/photo_thumbnail_box.css.scss
@@ -1,0 +1,69 @@
+@import "../../../lib/common";
+
+.photo_thumbnail_box {
+  border: 1px solid #ddd;
+}
+
+.photo_thumbnail_box__title {
+  color: #5d5d5d;
+  white-space: nowrap;
+}
+
+.photo_thumbnail_box__photos {
+  padding: 5px;
+  font-size: 0;
+  margin-left: -4px;
+  @include clearfix;
+
+  li {
+    width: 57px;
+    height: 57px;
+    margin-left: 4px;
+    margin-bottom: 4px;
+    float: left;
+  }
+}
+
+.photo_thumbnail_box {
+  border: 0;
+}
+
+.products_reviews_photo_thumbnail__summary {
+  display: none;
+}
+
+// 풀커스텀을 적용하려는 위젯에 커스텀 CSS로 넣을 것.
+// .products_reviews_photo_thumbnail__summary {
+//   display: block;
+//   text-align: center;
+//   font-size: 14px;
+//   margin: 15px;
+// }
+
+// .products_reviews_photo_thumbnail__divider {
+//   margin-right: 7px;
+// }
+
+// .products_reviews_photo_thumbnail__value {
+//   margin-left: 4px;
+// }
+
+// .photo_thumbnail_box__title {
+//   display: none;
+// }
+
+// .photo-review-thumbnail .review-image {
+//   opacity: 0.4;
+//   -webkit-transition: all 0.4s ease;
+//   -moz-transition: all 0.4s ease;
+//   -o-transition: all 0.4s ease;
+//   transition: all 0.4s ease;
+
+//   &:hover {
+//     opacity: 1;
+//   }
+// }
+
+// .photo-review-thumbnail .grayscale {
+//   display: none;
+// }

--- a/views/pc/products/reviews/_photo_thumbnail.html.erb
+++ b/views/pc/products/reviews/_photo_thumbnail.html.erb
@@ -1,0 +1,25 @@
+<%= content_for :content do %>
+  <% if widget.no_item_action?(items_count: review_images.count {|i| i != :placeholder}) %>
+    <% if widget.no_item_action_type == 'image' %>
+      <div class="products_reviews__no_item_image_box">
+        <%= image_tag(widget.no_item_image_url, class: 'products_reviews__no_item_image') %>
+      </div>
+    <% end %>
+  <% else %>
+    <div class="photo_thumbnail_box">
+      <div class="photo_thumbnail_box__title">
+        <%= widget.title.html_safe %>
+      </div>
+      <div class="products_reviews_photo_thumbnail__summary">
+        <span>전체 리뷰 <strong class="products_reviews_photo_thumbnail__value"><%= number_with_delimiter(product.reviews_count) %></strong>개</span>
+        <span class="products_reviews_photo_thumbnail__divider">|</span>
+        <span>포토 리뷰 <strong class="products_reviews_photo_thumbnail__value"><%= number_with_delimiter(product.photo_reviews_count) %></strong>개</span>
+        <span class="products_reviews_photo_thumbnail__divider">|</span>
+        <span>고객 만족도 <strong class="products_reviews_photo_thumbnail__value"><%= product.display_score %></strong></span>
+      </div>
+      <ul class="photo_thumbnail_box__photos">
+        <%= widget.render_review_images(self, review_images) %>
+      </ul>
+    </div>
+  <% end %>
+<% end %>


### PR DESCRIPTION
### 노트
- 포토썸네일을 기존에 사용하는 곳이 있으므로 특정 위젯에만 풀커스텀을 적용하기 위해서 view파일만 수정하고, 풀커스텀에 적용할 CSS는 커스텀 CSS로 추가하도록 한다.

### 작업 내용
- 리뷰 개수, 평점 정보 view에 추가하고 기본적으로 display none으로 지정
- 커스텀 CSS 작업
  - 상단 타이틀 숨김 처리
  - 리뷰 개수, 평점 정보 영역 보임 처리하고 CSS 적용
  - 포토 썸네일에 grayscale 영역 숨김 처리
  - 포토 썸네일 이미지를 기본적으로 opacity를 0.4로 보이도록 하고, 마우스 오버시 1로 되도록 처리

https://app.asana.com/0/6477641678483/328195358679419