### PR TITLE
EDIT - PC 상품상세페이지 리스트형 리뷰 위젯 풀커스텀 적용

### DIFF
--- a/assets/javascripts/pc/app/reviews.js.coffee
+++ b/assets/javascripts/pc/app/reviews.js.coffee
@@ -1,0 +1,351 @@
+class Reviews
+  collapse = ($review_content, complete) ->
+    $collapsed = $review_content.find(".review-content-collapsed").css(opacity: 0)
+    $expanded = $review_content.find(".review-content-expanded").css(opacity: 1)
+    $review_content.height($expanded.outerHeight())
+    setTimeout (->
+      $review_content.addClass("expanding")
+      lib.animation.fade_out $expanded, duration: "short"
+      lib.animation.fade_in $collapsed, duration: "short", complete: ->
+        $collapsed.css(opacity: 1)
+        $expanded.hide()
+        lib.animation.css $review_content, {
+          from_css: {height: $expanded.height()},
+          to_css: {height: $collapsed.height()},
+          complete: ->
+            $collapsed.css(opacity: "")
+            $expanded.css(opacity: "", display: "")
+            $review_content.removeClass("expanding expanded").css(height: "")
+            complete() if complete
+          }
+      ), 1
+
+  handle_link_expand: (args, auto_collapse) ->
+    args.elements.find(".link-collapse").click ->
+      collapse $(this).closest(".review-content")
+
+    args.elements.find(".review-content").on "review_content:filled", (e) ->
+      $review_content = $(e.target)
+      $review_content.data("filled", true)
+      $review_content.find(".link-collapse").click -> collapse $review_content
+      $review_content.trigger "review_content:loaded"
+
+    args.elements.find(".link-expand").click ->
+      $review = $(this).closest(".review")
+      $review_content = $review.find(".review-content")
+      if $review_content.hasClass("expanded")
+        collapse($review_content) if $review_content.data("toggle")
+      else
+        $review_content.on "review_content:loaded", (e) ->
+          if $review_content.data("filled") && $review_content.data("ready")
+            $collapsed = $review_content.find(".review-content-collapsed").css(opacity: 1)
+            $expanded = $review_content.find(".review-content-expanded").css(opacity: 0)
+            org_height = $review_content.height()
+            $review_content.height(org_height)
+            $expanded.hide()
+            setTimeout (->
+              $review_content.addClass("expanded expanding")
+              lib.animation.css $review_content, {
+                to_css: {height: $expanded.outerHeight()},
+                complete: ->
+                  lib.animation.fade_out $collapsed, duration: "short", complete: -> $collapsed.css(opacity: 0)
+                  app.form.enable_validate()
+                  $expanded.show()
+                  setTimeout (->
+                    lib.animation.fade_in $expanded, duration: "short", complete: ->
+                      $expanded.css(opacity: "", display: "")
+                      $review_content.css(height: "").removeClass("expanding")
+                  ), 0
+                }
+              ), 1
+            $review_content.off e
+
+        $review_content.data("ready", false)
+        $review_content_expanded = $(".review-content.expanded")
+        if !auto_collapse || $review_content_expanded.length == 0
+          $review_content.data("ready", true)
+          $review_content.trigger("review_content:loaded")
+        else
+          # expand된 것이 있으면 우선 줄인다.
+          collapse $review_content_expanded, ->
+            # 줄이고 나서 늘이기 시작
+            $review_content.data("ready", true)
+            $review_content.trigger("review_content:loaded")
+
+        if !$review.data("requested")
+          $review.data("requested", true)
+          $.getScript($review.data("expand-url"))
+
+  handle_show_full_reviews: ($link) ->
+    $link.on "ajax:beforeSend", ->
+      $review_content = $(this).closest(".review").find(".review-content")
+      if $review_content.hasClass("review-content-expanded")
+        lib.animation.height_down $review_content, ->
+          $review_content.removeClass("review-content-expanded")
+        false
+      else
+        $review_content.bind "review_content:loaded", (e) ->
+          if $review_content.hasClass("review-content-filled") && $review_content.hasClass("review-content-expanded")
+            lib.animation.height_up $review_content
+            $review_content.unbind e
+
+        $review_content_expanded = $(".review-content-expanded")
+        if $review_content_expanded.length > 0
+          lib.animation.height_down $review_content_expanded, ->
+            $review_content_expanded.removeClass("review-content-expanded")
+            $review_content.addClass("review-content-expanded").trigger("review_content:loaded")
+        else
+          $review_content.addClass("review-content-expanded").trigger("review_content:loaded")
+
+        !$review_content.hasClass("review-content-filled")
+
+  review_popup_loader: ($image_area) ->
+    $image = $image_area.find("img.review-image")
+    return unless $image.length
+
+    $image_container = $image_area.find(".thumbnail-container")
+    $anchor = if $image_container.length > 0 then $image_container else $image
+
+    $loader = $("<div id='review-popup-loader'></div>").css
+      top: $anchor.offset().top
+      left: $anchor.offset().left
+      width: 1
+      height: $anchor.height()
+      backgroundColor: '#ccdede'
+      position: 'absolute'
+    $("body").append($loader)
+    $loader.animate({
+      width: $anchor.width()
+    }, 280, lib.animation.ease_out)
+    setTimeout (->
+      $loader.animate({
+        opacity: 0
+      }, 280, lib.animation.ease_out)
+      setTimeout (->
+        $loader.remove()
+      ), 280
+    ), 1200
+
+app.reviews = new Reviews
+
+image_field_validate = ($input_field) ->
+  app.image_field_validator.validate($input_field)
+
+window.ClientSideValidations.validators.local["review_message"] = (element, options) ->
+  message = element.val()
+  if !message || message == element.closest("form").data("review-message-default")
+    return options.message
+
+add_score = ($review, delta_score, delta_total) ->
+  $score = $review.find(".like-score-container .like-score")
+  score = parseInt $score.text().replace(/\+\-/, "")
+  score += delta_score
+  if score > 0
+    $score.text("+" + score)
+  else if score < 0
+    $score.text(score)
+  else
+    $score.text("0")
+
+  $like_result = $review.find(".like-result")
+  app.like_result.add_score($like_result, delta_score, delta_total)
+
+$(document).on "click", "a.link-like", ->
+  $like_action = $(this).closest(".like-action")
+  liked = $like_action.hasClass("liked")
+  unliked = $like_action.hasClass("unliked")
+  if liked
+    final_score = 0
+    delta_score = -1
+    delta_total = -1
+  else
+    final_score = 1
+    if unliked
+      delta_score = 2
+      delta_total = 0
+    else
+      delta_score = 1
+      delta_total = 1
+
+  $review = $like_action.closest(".review")
+  $review.find(".like-action").each (i, e) ->
+    $e = $(e)
+    if liked
+      $e.removeClass("liked")
+    else
+      $e.addClass("liked")
+      if unliked
+        $e.removeClass("unliked")
+
+  add_score $review, delta_score, delta_total
+  $.ajax({
+    url: $like_action.data("url"),
+    type: "post",
+    data: {score: final_score}
+  })
+
+$(document).on "click", "a.link-unlike", ->
+  $like_action = $(this).closest(".like-action")
+  liked = $like_action.hasClass("liked")
+  unliked = $like_action.hasClass("unliked")
+  if unliked
+    final_score = 0
+    delta_score = 1
+    delta_total = -1
+  else
+    final_score = -1
+    if liked
+      delta_score = -2
+      delta_total = 0
+    else
+      delta_score = -1
+      delta_total = 1
+
+  $review = $like_action.closest(".review")
+  $review.find(".like-action").each (i, e) ->
+    $e = $(e)
+    if unliked
+      $e.removeClass("unliked")
+    else
+      $e.addClass("unliked")
+      if liked
+        $e.removeClass("liked")
+
+  add_score $review, delta_score, delta_total
+  $.ajax({
+    url: $like_action.data("url"),
+    type: "post",
+    data: {score: final_score}
+  })
+
+$(document).on "change", "input.input-file.one-image", ->
+  if !image_field_validate($(this))
+    return
+
+  $input = $(this)[0]
+  $preview_container = $(this).siblings(".preview-container")
+  $preview = $preview_container.find("img.preview")
+  if !lib.browser.supports_file_reader()
+    if this.value
+      $(this).siblings().find(".description").html(this.value.match(/[^\\]*\.(\w+)$/)[0])
+  else
+    if $input.files && $input.files[0]
+      $(this).siblings().find(".description").html($input.files[0].name)
+
+$(document).on "change", "select.select-rating", ->
+  $this = $(this)
+  if $this.val() == ""
+    rating = 5
+  else
+    rating = parseInt($this.val())
+
+  $stars = $this.closest(".form_review__score_container").find(".star")
+  $stars.each (i) ->
+    if i < rating
+      $(this).removeClass("star-empty")
+    else
+      $(this).addClass("star-empty")
+
+$(document).on "change", "select#category", ->
+  $select = $(this)
+  url = $select.data("url")
+  url_builder = new UrlBuilder(url)
+  category_id = $select.val()
+  url_builder.add_param("category_id", category_id) if category_id
+  $.getScript(url_builder.build())
+
+$(document).on "change", "select#sort", ->
+  $select = $(this)
+  url = $select.data("url")
+  url_builder = new UrlBuilder(url)
+  sort = $select.val()
+  url_builder.add_param("sort", sort) if sort
+  $.getScript(url_builder.build())
+
+format_select_rating = (item) ->
+  result = "<div class='select_score'>"
+  result += "<span class='select_score__text'>" + item.text + "</span>"
+  score = if item.id then parseInt(item.id) else 0
+  for i in [0...score] by 1
+    result += "<span class='select_score__star star'></span>"
+
+  for i in [score...5] by 1
+    result += "<span class='select_score__star star star-empty'></span>"
+
+  result += "</div>"
+
+$(document).on "history:updated", (e, elements) ->
+  $(elements).find("select.select-rating").each (i, e) ->
+    app.form.select($(e), {
+      formatResult: format_select_rating,
+      formatSelection: format_select_rating,
+      escapeMarkup: (m) -> m
+      })
+
+$(document).on "click", ".delete-review, .edit-review, .new_review, .review-edit-close", ->
+  $old_form = $("#review-edit-form")
+  if $old_form.length > 0
+    if !$(this).hasClass("delete-review") && !$(this).hasClass("edit-nonmember")
+      $old_form.animate({
+        opacity: 0
+      }, 250, lib.animation.ease_in)
+      setTimeout (->
+        $old_form.remove()
+      ), 250
+    else
+      $old_form.remove()
+
+$(document).on "click", ".edit-nonmember", ->
+  $link = $(this)
+  password = prompt($link.data("prompt"))
+  if password != null && password != ""
+    $.ajax({
+      url: $link.data("path"),
+      type: $link.data("action"),
+      data: {password: password}
+    })
+
+$(document).on "click", ".field-box.add-image-container", ->
+  app.review_image.add_image_container()
+
+$(document).on "ajax:before", "form.form-review", (e) ->
+  result = true
+  $form = $(this)
+  $form.find("input.review-option-field-value.required, select.review-option-field-value.required").each ->
+    $input = $(this)
+    if !$input.val()
+      alert($input.data("message"))
+      e.stopImmediatePropagation()
+      result = false
+      false
+
+  if result
+    $form.find("input.review-option-field-value-number").each ->
+      $input = $(this)
+      if !$input.val().match(/^[0-9]*$/)
+        alert($input.data("message"))
+        e.stopImmediatePropagation()
+        result = false
+        false
+
+  if result && $form.data("alert-requirement")
+    $message = $form.find("textarea#review_message")
+    length = $message.val().replace(/\s/g, '').length
+    minimum_length = $message.data("minimum-message-length")
+    if length < minimum_length
+      if !confirm($message.data("minimum-message-length-warning"))
+        e.stopImmediatePropagation()
+        result = false
+        false
+
+  if result && $form.data("disable-save-requirement")
+    $message = $form.find("textarea#review_message")
+    length = $message.val().replace(/\s/g, '').length
+    minimum_length = $message.data("minimum-message-length")
+    if length < minimum_length
+      alert($message.data("minimum-message-length-error"))
+      e.stopImmediatePropagation()
+      result = false
+      false
+
+  result

--- a/assets/javascripts/pc/app/states/products/reviews_state.js.coffee
+++ b/assets/javascripts/pc/app/states/products/reviews_state.js.coffee
@@ -1,0 +1,252 @@
+class ProductsReviewsState
+  constructor: ->
+    @appended_callback = (e, element) ->
+      app.reviews.handle_link_expand({elements: $(element)}, false)
+
+  on_enter: (old_state_name, args) ->
+    app.reviews.handle_link_expand(args, false)
+    @set_position_options()
+    @set_app_product_info(args)
+    @bind_nonmember_review_hint()
+    @bind_scroll(args.elements.find("#lista"))
+    $(document).on "infinite_scroll:appended", @appended_callback
+
+  on_exit: ->
+    $(document).off "infinite_scroll:appended", @appended_callback
+
+  set_app_product_info: (args) ->
+    @app_product_info = new AppProductInfo(args) if app.widget.is_new_tab()
+
+  set_position_options: ->
+    $review_option_search = $(".review-options-search")
+    if $review_option_search.hasClass("hidden")
+      $review_option_search.removeClass("hidden")
+      $(".review-options-search").addClass("hidden")
+
+  refresh_filter: ->
+    url_builder = new UrlBuilder(lib.history.get_current_url())
+    url_builder.remove_param("page")
+    url_builder.add_param("aloading", ".page")
+    url_builder.add_param("atarget", "reviews")
+
+    $score_summary = $(".score-summary")
+
+    scores = []
+    $score_summary.find("li.selected").each (i, element) ->
+      scores.push($(element).data("score"))
+
+    if scores.length > 0
+      url_builder.add_param("scores", JSON.stringify(scores))
+    else
+      url_builder.remove_param("scores")
+
+    $link_photo_reviews = $score_summary.find("a.link-photo-reviews")
+    if $link_photo_reviews.hasClass("selected")
+      url_builder.add_param("filter", $link_photo_reviews.data("filter"))
+    else
+      url_builder.remove_param("filter")
+
+    $.getScript url_builder.build()
+
+  on_focus: ($form) ->
+    $textarea = $form.find("textarea.new-review-form")
+    return if $textarea.data("triggered")
+    $textarea.data("triggered", true)
+
+    $review_option_fields = $form.find(".review-option-fields")
+    if $review_option_fields.length > 0
+      # IE7에서 .show() 대신 .css(display: "block")을 해줘야됨. 이유는 모름.
+      # https://app.asana.com/0/80420144146943/91330956610548
+      $review_option_fields.css(marginTop: -($review_option_fields.height() + 50), opacity: 0, display: "block")
+      if Modernizr.cssanimations
+        setTimeout (->
+          $review_option_fields.addClass("anim")
+          $review_option_fields.css(marginTop: 0)
+          setTimeout (->
+            $review_option_fields.css(opacity: 1)
+            ), 200
+          ), 0
+      else
+        setTimeout (->
+          $review_option_fields.animate {marginTop: 0}, 200, lib.animation.ease_out
+          setTimeout (->
+            $review_option_fields.animate {opacity: 1}, 200, lib.animation.ease_out
+            ), 200
+          ), 0
+
+    $nonmember_review_tmpl = $("#nonmember-review-tmpl")
+    if $nonmember_review_tmpl.length > 0
+      $nonmember_review = $($nonmember_review_tmpl.html())
+      $nonmember_review.find("#review_user_name").attr("autocomplete", "off")
+      $nonmember_review.find("#review_password").attr("autocomplete", "off")
+      $form.prepend($nonmember_review)
+      if Modernizr.cssanimations
+        setTimeout (->
+          $nonmember_review.css(top: 0)
+          $form.find(".message-field").css("padding-top": 77)
+          setTimeout (->
+            $nonmember_review.find(".content-container").css(opacity: 1)
+            ), 300
+          ), 0
+      else
+        setTimeout (->
+          $nonmember_review.animate {top: 0}, 300, lib.animation.ease_out
+          $form.find(".message-field").animate {"padding-top": 77}, 300, lib.animation.ease_out
+          setTimeout (->
+            $nonmember_review.find(".content-container").animate {opacity: 1}, 200
+            ), 300
+          ), 0
+      lib.animation.animate($form.addClass("show-nonmember-review"))
+
+      $form.find("#review_user_name").focus()
+
+      $form.bind "ajax:before", ->
+        $input = $form.find("#review_user_name")
+        if !$input.val()
+          alert($input.data("presence-warning"))
+          return false
+
+        $input = $form.find("#review_password")
+        if !$input.val()
+          alert($input.data("presence-warning"))
+          return false
+
+    $review_policy_tmpl = $("#review-policy-tmpl")
+    if $review_policy_tmpl.length > 0
+      $review_policy = $($review_policy_tmpl.html())
+      $form.prepend($review_policy)
+      if Modernizr.cssanimations
+        setTimeout (->
+          $review_policy.css(top: 0)
+          $form.find(".message-field").css("padding-top": 73)
+          setTimeout (->
+            $review_policy.find(".content-container").css(opacity: 1)
+            ), 300
+          ), 0
+      else
+        setTimeout (->
+          $review_policy.animate {top: 0}, 300, lib.animation.ease_out
+          $form.find(".message-field").animate {"padding-top": 73}, 300, lib.animation.ease_out
+          setTimeout (->
+            $review_policy.find(".content-container").animate {opacity: 1}, 200
+            ), 300
+          ), 0
+
+      $view_detail = $(".view-detail")
+      $("#review-policy-detail").remove()
+      $review_policy_detail = null
+      $view_detail.on "mouseenter", ->
+        if !$review_policy_detail
+          $review_policy_detail = $("<div id='review-policy-detail'></div>").html($("#review-policy-detail-tmpl").html()).appendTo("body")
+          popup_bottom = $review_policy_detail.height() + 100
+          if popup_bottom > $(window).height()
+            app.window.set_height(popup_bottom)
+
+        if Modernizr.cssanimations
+          $review_policy_detail.addClass("hover")
+        else
+          $review_policy_detail.
+            show().
+            animate({top: 45}, 0, lib.animation.ease_out).
+            animate({opacity: 1}, 0)
+
+      $view_detail.on "mouseleave", ->
+        if Modernizr.cssanimations
+          $review_policy_detail.removeClass("hover")
+        else
+          $review_policy_detail.
+            animate({top: 30}, 0, lib.animation.ease_out).
+            animate({opacity: 0}, 0)
+          setTimeout (->
+            $review_policy_detail.hide()
+          ), 100
+
+  bind_form: ($form) ->
+    app.review_image.set_form($form)
+    $textarea = $form.find("textarea.new-review-form")
+    $textarea.off "focus"
+    not_creatable_reason = $form.data('not-creatable-reason')
+    if not_creatable_reason
+      $textarea.on "focus", ->
+        if !$textarea.data("login-required") || lib.data.get("username")
+          $this = $(this)
+          $this.blur()
+          alert(not_creatable_reason)
+          false
+    else if $form.data("already-posted")
+      if lib.data.get("allow-multiple-reviews-per-product")
+        ignore_once = false
+        $textarea.one "focus", (e) =>
+          if confirm($form.data("already-posted"))
+            @on_focus($form)
+            result = true
+          else
+            $(e.target).blur()
+            result = false
+
+          result
+      else
+        $textarea.on "focus", ->
+          $this = $(this)
+          $this.blur()
+          alert(lib.i18n.t("review_already_posted"))
+          false
+    else
+      $textarea.on "focus", (e) =>
+        if !$textarea.data("login-required") || lib.data.get("username")
+          @on_focus($form)
+
+  bind_nonmember_review_hint: ->
+    return if lib.browser.supports_media_query()
+    set_hint_visibility = ->
+      $hint = $(".nonmember_review__hint")
+      if $(window).width() > 940
+        $hint.show()
+      else
+        $hint.hide()
+
+    $(window).resize -> set_hint_visibility()
+    set_hint_visibility()
+
+  bind_scroll: ($list) ->
+    $list.als
+      visible_items: 5
+      scrolling_items: 5
+      orientation: "horizontal"
+      circular: "yes"
+      autoscroll: "yes"
+      interval: 4000
+      direction: "left"
+
+app.products_reviews_state = new ProductsReviewsState
+
+$(document).on "history:updated", (e, element) ->
+  $element = $(element)
+  $form = $element.find("#form-new-product-review").addBack("#form-new-product-review")
+  app.products_reviews_state.bind_form($form) if $form.length
+
+  $element.find(".show-reviews-index").click ->
+    app.window.redirect_to $(this).data("reviews-index-url")
+
+  $element.find("a.link-score").click (e) ->
+    $link = $(e.currentTarget)
+    $link.closest("li").toggleClass("selected")
+    app.products_reviews_state.refresh_filter()
+
+  $element.find("a.link-photo-reviews").click (e) ->
+    $(e.currentTarget).toggleClass("selected")
+    app.products_reviews_state.refresh_filter()
+
+  $element.find("a.review-options-search-toggle").click ->
+    $this = $(this)
+    if $this.hasClass("searching")
+      $this.removeClass("searching")
+    else
+      $this.addClass("searching")
+
+    $option_search_bar = $(".review-options-search")
+    if $option_search_bar.hasClass("hidden")
+      $option_search_bar.removeClass("hidden")
+      lib.animation.height_up $option_search_bar
+    else
+      lib.animation.height_down $option_search_bar, -> $option_search_bar.addClass("hidden")

--- a/assets/stylesheets/pc/app/comments.css.scss
+++ b/assets/stylesheets/pc/app/comments.css.scss
@@ -1,0 +1,164 @@
+@import "../lib/arrow";
+@import "../lib/common";
+@import "compass/css3/opacity";
+@import "compass/css3/transition";
+
+.comments-container {
+  position: relative;
+  border: 1px solid #e2e2e2;
+  margin-top: 7px;
+  margin-right: 30px;
+  padding: 10px 15px;
+  text-align: left;
+  max-width: 800px;
+
+  .arrow-top:before {
+    @include arrow-top(8px, transparent, #e2e2e2);
+    position: absolute;
+    top: -8px;
+    left: 20px;
+    content: '';
+  }
+
+  .arrow-top:after {
+    @include arrow-top(7px, transparent, white);
+    position: absolute;
+    top: -7px;
+    left: 21px;
+    content: '';
+  }
+
+  ul {
+    li {
+      display: block;
+      border-top: 1px solid #f6f6f6;
+      color: #333333;
+      overflow: hidden;
+      position: relative;
+
+      .inner {
+        padding: 10px 0;
+      }
+
+      &:first-child {
+        border-top: none;
+      }
+
+      .lpane {
+        float: left;
+        font-weight: bold;
+        @include font-default;
+        padding: 0;
+        width: 62px;
+        margin-left: 5px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .rpane {
+        float: none;
+        padding-left: 72px;
+      }
+
+      .error-message {
+        color: red;
+      }
+
+      .message {
+        word-wrap: break-word;
+        position: relative;
+      }
+
+      .comment-message-edit {
+        display: none;
+        position: absolute;
+        top: -1px;
+        left: -1px;
+        border: 1px solid #aaa;
+        width: 80%;
+      }
+
+      &.editing {
+        .comment-message-edit {
+          display: block;
+        }
+
+        span {
+          opacity: 0;
+        }
+      }
+    }
+  }
+
+  .new-comments {
+    border: 1px solid #e2e2e2;
+    padding: 4px 65px 4px 12px;
+    position: relative;
+
+    .btn {
+      position: absolute;
+      right: 4px;
+      top: 4px;
+    }
+
+    input {
+      width: 100%;
+    }
+
+    input {
+      font-size: 13px;
+      height: 24px;
+      line-height: 24px;
+
+      &.btn {
+        line-height: 24px;
+        font-size: 14px;
+      }
+    }
+  }
+
+  ul li.hover .edit-comment-container {
+    @include opacity(1);
+  }
+}
+
+.edit-comment-container {
+  position: absolute;
+  top: 6px;
+  right: 3px;
+  @include opacity(0);
+  @include transition(opacity 0.2s);
+}
+
+.comment__inner {
+  position: relative;
+  padding: 10px 15px !important;
+}
+
+.comment__rpane {
+  padding-left: 110px !important;
+  padding-right: 80px;
+  color: #8D8D8D;
+}
+
+.comment__created_at {
+  position: absolute;
+  top: 6px;
+  right: 15px;
+  color: #A5A5A5;
+}
+
+.comments__new_comment {
+  margin-top: 10px;
+}
+
+.comments__submit {
+  border: 0;
+  border-left: 1px solid #dadada;
+  line-height: 32px;
+  top: 0 !important;
+  right: 0 !important;
+  width: 60px;
+  color: #A5A5A5;
+}

--- a/assets/stylesheets/pc/app/products/reviews/list.css.scss
+++ b/assets/stylesheets/pc/app/products/reviews/list.css.scss
@@ -1,0 +1,330 @@
+@import "../../../lib/common";
+@import "compass/css3/transition";
+@import "../../../lib/css3/opacity";
+
+.products_reviews_list__summary_with_form {
+  padding: 35px;
+  background: #F6F5F5;
+}
+
+.products_reviews_list__summary {
+  text-align: center;
+}
+
+.products_reviews_list__reviews_count_with_score {
+  font-size: 20px;
+}
+
+.products_reviews_list__summary_value {
+  font-weight: bold;
+}
+
+.products_reviews_list__summary_info_divider {
+  margin-left: 5px;
+  margin-right: 15px;
+}
+
+.products_reviews_list__likes_info {
+  margin-top: 10px;
+  margin-bottom: 20px;
+  font-size: 13px;
+}
+
+.products_reviews_list__likes_icon {
+  margin-right: 3px;
+}
+
+.products_reviews_list__likes_value {
+  color: #A33E3C;
+  font-weight: bold;
+}
+
+.products_reviews_list__thumbnails_container {
+  position: relative;
+  padding: 0 40px;
+  margin-bottom: 40px;
+}
+
+.products_reviews_list__review_image_item {
+  width: 170px;
+  height: 170px;
+  margin: 0 13px;
+}
+
+.products_reviews_list__review_image_item--last_review_item {
+  position: relative;
+  text-align: center;
+  line-height: 170px;
+  font-size: 13px;
+  font-weight: bold;
+}
+
+.products_reviews_list__review_image {
+  width: 100%;
+  margin-top: 0 !important;
+}
+
+.products_reviews_list__last_item_indicator {
+  position: absolute;
+  font-size: 40px;
+  top: -46px;
+}
+
+.products_reviews_list__thumbnail_back_scroll {
+  position: absolute;
+  top: 75px;
+  left: -35px;
+  cursor: pointer;
+  font-size: 20px;
+}
+
+.products_reviews_list__thumbnail_forward_scroll {
+  position: absolute;
+  top: 75px;
+  right: -35px;
+  cursor: pointer;
+  font-size: 20px;
+}
+
+.products_reviews_list_header {
+  font-size: 16px;
+  padding: 0 35px 20px 35px;
+  border-bottom: 1px solid #dadada;
+}
+
+.products_reviews_list_header__upper {
+  font-family: "나눔고딕", "NanumGothic", "맑은 고딕", "Malgun Gothic", "돋움", "Dotum", "굴림", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  position: relative;
+  line-height: 42px;
+  @include clearfix;
+}
+
+.products_reviews_list_header__sort_type {
+  color: #949494;
+  font-size: 14px;
+  letter-spacing: -1px;
+}
+
+.products_reviews_list_header__sort_container {
+  float: right;
+  margin-top: 6px;
+
+  .review_option_type {
+    max-width: none;
+  }
+
+  #review_option_type_1 {
+    width: 220px;
+  }
+
+  #review_option_type_2 {
+    width: 170px;
+  }
+
+  #review_option_type_3 {
+    width: 160px;
+  }
+
+  .review_option_type__dropdown_button {
+    border-left: 0;
+  }
+
+  .review_option_type__name {
+    color: #8E8E8E;
+  }
+}
+
+.products_reviews_list_review {
+  padding: 30px 35px 8px 35px;
+}
+
+.products_reviews_list_review__info_container {
+  float: right;
+  margin-bottom: 30px;
+  min-width: 205px;
+  font-family: "나눔고딕", "NanumGothic", "맑은 고딕", "Malgun Gothic", "돋움", "Dotum", "굴림", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.products_reviews_list_review__info {
+  border-top: 1px solid #dadada;
+  padding: 7px 5px;
+
+  &:first-child {
+    padding-top: 0;
+    border-top: none;
+  }
+}
+
+.products_reviews_list_review__info_title {
+  line-height: 18px;
+  color: #a8a8a8;
+  display: inline-block;
+  width: 70px;
+}
+
+.products_reviews_list_review__info_value {
+  line-height: 18px;
+  color: #8C8C8C;
+  font-weight: bold;
+  display: inline-block;
+}
+
+.products_reviews_list_review__star_wrap {
+  @include clearfix;
+  display: inline-block;
+}
+
+.products_reviews_list_review__score_text {
+  float: left;
+  font-size: 15px;
+  color: #363636;
+  font-weight: bold;
+}
+
+.products_reviews_list_review__star_rating_container {
+  float: left;
+  font-size: 0;
+  margin-left: 20px;
+  margin-top: 2px;
+}
+
+.products_reviews_list_review__star {
+  margin-right: 8px;
+}
+
+.products_reviews_list_review__review_tag {
+  float: left;
+  margin-left: 2px;
+  margin-top: -1px;
+}
+
+.products_reviews_list_review__review_content {
+  font-size: 13px;
+}
+
+.products_reviews_list_review__review_content_inner {
+}
+
+.products_reviews_list_review__message {
+
+}
+
+.products_reviews_list_review__review_message {
+  max-height: 105px;
+}
+
+.products_reviews_list_review__review_message--collapsed {
+}
+
+.products_reviews_list_review__review_message--collapsed5 {
+}
+
+.products_reviews_list_review__see_more {
+  
+}
+
+
+.products_reviews_list_review__actions_container {
+  line-height: 30px;
+  text-align: left;
+  @include clearfix;
+}
+
+.products_reviews_list_review__like {
+  @include clearfix;
+  float: left;
+}
+
+.products_reviews_list_review__like_icon {
+  float: left;
+}
+
+.products_reviews_list_review__like_text {
+  float: left;
+  margin-left: 5px;
+}
+
+.products_reviews_list_review__like_link {
+  font-size: 18px;
+}
+
+.products_reviews_list_review__like_link--liked {
+  color: #A33E3A;
+  display: none !important;
+}
+
+.products_reviews_list_review__comment_info {
+  display: inline-block;
+  float: left;
+  margin-left: 12px;
+}
+
+.products_reviews_list_review__comments_count {
+  margin-left: 5px;
+}
+
+.product_reviews_list {
+  .review-options {
+    margin-right: 0;
+  }
+
+  .review-option-title {
+    width: 12%;
+    color: #8D8D8D;
+    font-weight: normal !important;
+  }
+
+  .review_option__content {
+    color: #8D8D8D !important;
+  }
+
+  .comments-container {
+    margin-top: 20px;
+    margin-right: 0;
+    border: 0;
+    border-top: 1px solid #e2e2e2;
+    padding: 10px 0;
+  }
+
+  .like-action {
+    @include clearfix;
+  }
+
+  .like-action.liked {
+    .link-like {
+      background: white;
+      border-color: white;
+      color: #A33E3A;
+    }
+
+    .products_reviews_list_review__like_link--like {
+      display: none !important;
+    }
+
+    .products_reviews_list_review__like_link--liked {
+      display: block !important;
+    }
+  }
+}
+
+.products_reviews_list_review__collapse {
+  margin-top: 10px;
+  position: relative;
+  height: 20px;
+}
+
+.products_reviews_list_review__collapse_button {
+  font-size: 14px;
+  background: #CCCCCC;
+  color: white;
+  -moz-border-radius: 24px;
+  -webkit-border-radius: 24px;
+  border-radius: 24px;
+  width: 30px;
+  height: 30px;
+  line-height: 28px;
+  text-align: center;
+  position: absolute;
+  top: 0;
+  left: 50%;
+}

--- a/views/pc/comments/_comment.html.erb
+++ b/views/pc/comments/_comment.html.erb
@@ -1,0 +1,24 @@
+<% editable = comment.editable?(current_user) %>
+<%= content_tag :li, class: 'comment hoverable', id: "comment_#{comment.new_record? ? "{{id}}" : comment.id}" do %>
+  <div class="inner comment__inner">
+    <%= content_tag :div, comment.user_display_name, class: 'lpane', title: comment.user_display_name %>
+    <div class="rpane comment__rpane">
+      <div class="error-message rfloat"></div>
+      <div class="message">
+        <span><%= comment.message.html %></span>
+        <% if editable %>
+          <%= text_field_tag :message, comment.message, class: 'comment-message-edit', data: {update_url: comment_path(comment), message_required: t('comments.edit.message_required')} %>
+        <% end %>
+      </div>
+    </div>
+    <div class="comment__created_at">
+      <%= comment.created_at ? comment.created_at.strftime('%-m.%-d') : nil %>
+    </div>
+    <% if editable %>
+      <div class="edit-comment-container">
+        <a class="link-edit-comment btn-small btn-white"><%= t('edit') %></a>
+        <%= link_to t('destroy'), comment_path(comment), method: :delete, remote: true, class: 'link-delete-comment btn-small btn-white', data: {confirm: t('comments.confirm_destroy')} %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/views/pc/products/reviews/_form.html.erb
+++ b/views/pc/products/reviews/_form.html.erb
@@ -1,0 +1,18 @@
+<% return if widget.gallery_style? %>
+<%= content_tag :div, class: "widget new-review first #{'no-writable' if !@brand.review_writable?}" do %>
+  <div class="widget-heading">
+    <div class="widget-title">
+      <%= widget.title.html_safe %>
+    </div>
+    <% if @brand.reviews_index_url.present? && !openmarket? %>
+      <%= content_tag :div, widget.reviews_button_title, class: 'rfloat btn show-reviews-index', data: {reviews_index_url: @brand.reviews_index_url} %>
+    <% end %>
+  </div>
+  <% if display_write_form %>
+    <div class="widget-body">
+      <%= render 'reviews/form' %>
+      <%= render 'products/reviews/misc_form_templates' %>
+      <%= render 'common/shared/form_upload_image' %>
+    </div>
+  <% end %>
+<% end %>

--- a/views/pc/products/reviews/_list.html.erb
+++ b/views/pc/products/reviews/_list.html.erb
@@ -1,0 +1,78 @@
+<% widget_style = WidgetStyle.key_string(widget.widget_style) %>
+<% title widget.name %>
+<%= content_for :content do %>
+  <% if no_item_action %>
+    <% if widget.no_item_action_type == 'image' %>
+      <div class="products_reviews__no_item_image_box">
+        <%= image_tag(widget.no_item_image_url, class: 'products_reviews__no_item_image') %>
+      </div>
+    <% end %>
+  <% else %>
+    <%= render 'products/reviews/product_info' %>
+    <%= content_tag :div, class: "product_reviews_#{widget_style}" do %>
+      <% display_write_form = brand.review_writable? && display_write_form?(@product) && allow_comment? %>
+      <div class="products_reviews_list__summary_with_form">
+        <div class="products_reviews_list__summary">
+          <div class="products_reviews_list__reviews_count_with_score">
+            <span>전체 리뷰</span>
+            <span class="products_reviews_list__summary_value"><%= product.meta_visible_reviews.count %></span>개
+            <span class="products_reviews_list__summary_info_divider">|</span>
+            <span>포토 리뷰</span>
+            <span class="products_reviews_list__summary_value"><%= product.meta_visible_reviews.with_photo.count %></span>개
+            <span class="products_reviews_list__summary_info_divider">|</span>
+            <span>고객 만족도</span>
+            <span class="products_reviews_list__summary_value"><%= product.display_score('-') %></span>
+          </div>
+          <div class="products_reviews_list__likes_info">
+            <i class="fa fa-heart products_reviews_list__likes_icon"></i>
+            <%= product.likes_count %>명 중 <span class="products_reviews_list__likes_value"><%= product_reviews_summary.count %></span>명이 이 제품을 좋아합니다.
+          </div>
+          <div class="products_reviews_list__thumbnails_container">
+            <div id="lista" class="als-container">
+              <span class="als-prev"><div class="products_reviews_list__thumbnail_back_scroll">◀</div></span>
+              <div class="products_reviews_list__thumbnails als-viewport">
+                <ul class="als-wrapper">
+                  <% review_images.each_with_index do |review_image, i| %>
+                    <li class="products_reviews_list__review_image_item als-item">
+                      <%= content_tag(
+                        :a,
+                        class: 'link-fullscreen-popup',
+                        data: {
+                          url: photo_review_popup_review_path(review_image.model)
+                        }
+                      ) do %>
+                        <%= image_tag review_image.url(:thumbnail), class: 'products_reviews_list__review_image smooth' %>
+                      <% end %>
+                    </li>
+                  <% end %>
+                  <% if review_images.count == 1 %>
+                    <li class="als-item" style="pointer-events: none;"></li>
+                  <% end %>
+                </ul>
+              </div>
+              <span class="als-next"><div class="products_reviews_list__thumbnail_forward_scroll">▶</div></span>
+            </div>
+          </div>
+        </div>
+        <% if display_write_form %>
+          <div class="products_reviews_list__form">
+            <%= render 'reviews/form' %>
+            <%= render 'products/reviews/misc_form_templates' %>
+            <%= render 'common/shared/form_upload_image' %>
+          </div>
+        <% end %>
+      </div>
+      <%= content_tag :div, class: "widget widget-reviews pagination-list #{'hidden' if !product.meta_visible_reviews?} #{'no-data' if product_reviews.total_count == 0}" do %>
+        <%= render 'products/reviews/list/header' %>
+        <div>
+          <%= content_tag :div, class: "widget-body product_reviews_#{widget_style}__body" do %>
+            <%= render "#{widget.base_path}/body" %>
+          <% end %>
+          <div class="product_reviews__footer">
+            <%= render "#{widget.base_path}/footer" %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/views/pc/products/reviews/list/_header.html.erb
+++ b/views/pc/products/reviews/list/_header.html.erb
@@ -1,0 +1,13 @@
+<div class="products_reviews_list_header">
+  <div class="products_reviews_list_header__upper">
+    <span class="products_reviews_list_header__sort_type selected">
+      <strong><%= ReviewSort.t(@review_sort) %></strong>
+    </span>
+    <% review_sort_types.select {|r| r != @review_sort}.each do |review_sort_type| %>
+    <span class="review-sort-type-column"> | </span><%= link_to ajax_path(sort: review_sort_type, aloading: '.page'), remote: true do %><span class="products_reviews_list_header__sort_type"><%= ReviewSort.t(review_sort_type) %></span><% end %>
+    <% end %>
+    <div class="products_reviews_list_header__sort_container">
+      <%= render 'reviews/review_options_search', hidden: @review_option_filter.empty? %>
+    </div>
+  </div>
+</div>

--- a/views/pc/products/reviews/list/_review.html.erb
+++ b/views/pc/products/reviews/list/_review.html.erb
@@ -1,0 +1,123 @@
+<%
+message_initial_rows = widget.message_initial_rows == 0 ? 3 : widget.message_initial_rows
+is_my_last_review = my_last_review?(review) if local_assigns[:is_my_last_review].nil?
+%>
+<%= content_tag_for :li, review, class: "products_reviews_list_review #{'product-my-first-review' if is_my_last_review}", data: {expand_url: expand_review_path(review.id, widget_env: widget_env, widget_id: widget.id)} do %>
+  <div class="products_reviews_list_review__info_container">
+    <ul>
+      <li class="products_reviews_list_review__info">
+        <div class="products_reviews_list_review__info_title"><%= t('products.reviews.author_title') %></div>
+        <div class="products_reviews_list_review__info_value"><%= review.user_display_name %></div>
+      </li>
+      <% if @brand.review_show_created_at %>
+        <li class="products_reviews_list_review__info">
+          <div class="products_reviews_list_review__info_title"><%= t('products.reviews.posted_at_title') %></div>
+          <div class="products_reviews_list_review__info_value"><%= review.created_at.strftime("%Y. %-m. %-d") %></div>
+        </li>
+      <% end %>
+      <% case @brand.review_author_display_type %>
+      <% when ReviewAuthorDisplayType::AUTHOR_TYPE %>
+        <li class="products_reviews_list_review__info">
+          <div class="products_reviews_list_review__info_title"><%= t('products.reviews.author_grade_title') %></div>
+          <div class="products_reviews_list_review__info_value">
+            <% if review.brand_author_type %>
+              <%= review.brand_author_type.title %>
+            <% elsif review.pinned_to_top? %>
+              <span class="fa fa-bookmark"></span> <%= t('products.reviews.best_review') %>
+            <% else %>
+              <%= review.writer_type %>
+            <% end %>
+          </div>
+        </li>
+      <% when ReviewAuthorDisplayType::USER_GRADE %>
+        <% if review.brand_user_grade_name.present? %>
+          <li class="products_reviews_list_review__info">
+            <div class="products_reviews_list_review__info_title"><%= t('products.reviews.user_grade_title') %></div>
+            <div class="products_reviews_list_review__info_value">
+              <%= review.brand_user_grade_name %>
+            </div>
+          </li>
+        <% end %>
+        <% if review.pinned_to_top? %>
+          <li class="products_reviews_list_review__info">
+            <div class="products_reviews_list_review__info_title"><%= t('products.reviews.review_grade_title') %></div>
+            <%= content_tag :span, nil, class: 'fa fa-bookmark', title: t('products.reviews.best_review') %> <div class="products_reviews_list_review__info_value"><%= t('products.reviews.best_review') %></div>
+          </li>
+        <% end %>
+      <% end %>
+    </ul>
+  </div>
+  <%= content_tag :div, class: "l-contents panel #{'photo-review' if review.images_count > 0}" do %>
+    <div class="panel-heading no-border score ">
+      <div class="products_reviews_list_review__star_wrap">
+        <% if review.brand_author_type && review.brand_author_type[:image] %>
+          <%= content_tag :div, class: 'brand-author-type-image-container', style: "margin-top: #{(14.0 - review.brand_author_type.image.dimension[1]) * 0.5}px" do %>
+            <%= image_tag review.brand_author_type.image_url %>
+          <% end %>
+          <div class="divider">|</div>
+        <% end %>
+        <% if @brand.review_show_score %>
+          <%= content_tag :div, ReviewScore.t(review.score || ReviewScore::BEST), class: "products_reviews_list_review__score_text #{local_assigns[:text_rating_class]}" %>
+          <% if brand.review_show_score %>
+            <%= content_tag :div, class: "products_reviews_list_review__star_rating_container #{local_assigns[:star_rating_class]}" do %>
+              <% (1..5).each do |i| %>
+                <%= content_tag :span, nil, class: "star #{'star-empty' if review.score && i > review.score} products_reviews_list_review__star" %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% else %>
+          <%= content_tag :div, class: "like-result #{'like-result--no_likes' if review.likes_count.zero?}" do %>
+           <%= t('reviews.how_many_people_thought_helpful_html', likes_count: review.likes_count, plus_likes_count: review.plus_likes_count) %>
+          <% end %>
+        <% end %>
+
+        <% photo_tag = !widget.show_image_when_collapsed %>
+        <div class="products_reviews_list_review__review_tag">
+          <% if photo_tag && review.photo? %>
+            <div class="review-tag review-tags__camera">
+              <% w, h = widget.camera_icon.dimension %>
+              <%= image_tag(
+                widget.camera_icon_url,
+                width: w,
+                height: h,
+                class: 'review-tags__camera_img',
+                title: t('reviews.review_has_photo')
+              ) %>
+            </div>
+          <% end %>
+          <% if review.new? %>
+            <%= content_tag :span, 'NEW', class: 'review-tag new-tag', title: t('reviews.review_written_recently') %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    <%= content_tag :div, class: "review-content #{'expanded' if widget.message_initial_rows == 0} products_reviews_list_review__review_content" do %>
+      <%= content_tag(:div, t('products.reviews.my_last_review', user: review.user_display_name), class: 'my-first-review') if is_my_last_review %>
+      <div class="review-content-inner review-content-collapsed">
+        <div class="panel-body no-border">
+          <a class="message link-expand">
+            <div class="review_message review_message--collapsed review_message--collapsed<%= message_initial_rows %> products_reviews_list_review__review_message">
+              <% if widget.review_message_all_collapsed? %>
+                <% show_see_more = true %>
+                <%= widget.collapsed_title %>
+              <% else %>
+                <% show_see_more = !widget.show_image_when_collapsed && review.images_count > 0 %>
+                <%= review.message_with_prefix(tag: true) %>
+              <% end %>
+            </div>
+            <%= content_tag(
+              :div,
+              t('reviews.see_more'),
+              class: "mall-link-color see-more #{'see-more--force-show' if show_see_more} products_reviews_list_review__see_more",
+            ) %>
+          </a>
+          <%= render('reviews/images', review: review) if widget.show_image_when_collapsed %>
+        </div>
+        <%= render 'reviews/review_footer', review: review, show_comments: false %>
+      </div>
+      <div class="review-content-inner review-content-expanded">
+        <%= render 'reviews/review_content_expanded', review: review %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/views/pc/reviews/_action_likes.html.erb
+++ b/views/pc/reviews/_action_likes.html.erb
@@ -1,0 +1,36 @@
+<%
+likes = likes?(review)
+like = get_like(review)
+%>
+<%= content_tag :div, class: "inline like-action #{(like.score > 0 ? 'liked' : 'unliked') if likes} products_reviews_list_review__like", data: {url: like_review_path(review)} do %>
+  <div class="products_reviews_list_review__like_icon">
+    <a class="products_reviews_list_review__like_link products_reviews_list_review__like_link--like link-like">♡</a>
+    <a class="products_reviews_list_review__like_link products_reviews_list_review__like_link--liked link-like">♥</a>
+  </div>
+  <div class="products_reviews_list_review__like_text">좋아요 <%= review.total_score %>개</div>
+  <% if local_assigns[:hide_edit] != true %>
+    <%
+    deletable = review.deletable?(current_user)
+    editable = review.editable?(current_user)
+    %>
+    <% if deletable || editable %>
+      <div class="inline edit-review-container">
+        <% if editable %>
+          <% edit_path = edit_review_path(review, group: @group_by, widget_id: widget.id, review: params[:review]) %>
+          <% if current_user %>
+            <%= link_to edit_path, method: :post, remote: true do %>
+              <span class="edit-review hoverable"><%= t('edit') %></span>
+            <% end %>
+          <% else %>
+            <%= content_tag :span, t('edit'), class: 'edit-review hoverable edit-nonmember', data: {action: 'POST', path: edit_path, prompt: t('reviews.likes.prompt_guest_edit')} %>
+          <% end %>
+        <% end %>
+        <div class="inline edit-review-container-line"></div>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>
+<div class="products_reviews_list_review__comment_info">
+  <span class="products_reviews_list_review__comment_icon"><i class="fa fa-no-comment"></i></span>
+  <span class="products_reviews_list_review__comments_count">댓글 <%= review.comments_count %>개</span>
+</div>

--- a/views/pc/reviews/_comments.html.erb
+++ b/views/pc/reviews/_comments.html.erb
@@ -1,0 +1,22 @@
+<% if @brand.review_enable_user_comments || review.comments_count > 0 %>
+  <%= content_tag :div, class: "comments-container ie-opacity-fix #{'hidden' if !allow_comment? && review.comments_count == 0} products_reviews_list_review__comments_container" do %>
+    <ul>
+      <%= render review.comments if review.comments_count > 0 %>
+    </ul>
+    <% if @brand.review_enable_user_comments && allow_comment? %>
+      <div class="new-comments ie-opacity-fix comments__new_comment">
+        <%= form_for Comment.new, url: comments_path, validate: true, remote: true, data: {login_required: true} do |f| %>
+          <%= f.text_field :message, placeholder: t('comments.attributes.message.placeholder'), class: 'input-block', data: {login_required: true} %>
+          <%= f.hidden_field :review_id, value: review.id %>
+          <%= content_tag :button, 'OK', class: 'btn btn-white ie-opacity-fix comments__submit', type: 'submit' %>
+          <input type="hidden" name="tracking_id">
+          <% if current_user %>
+            <script class="blueprint" type="text/x-jquery-tmpl">
+              <%= render "comments/comment", comment: Comment.template(current_user, review) %>
+            </script>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/views/pc/reviews/_form.html.erb
+++ b/views/pc/reviews/_form.html.erb
@@ -1,0 +1,70 @@
+<div>
+  <% review = new_review(review_source: WrittenSource::BRAND_PC_PRODUCT) if !review %>
+  <%= content_tag :div, nil, id: 'data', data: {
+    allow_multiple_reviews_per_product: @brand.review_allow_multiple_reviews_per_product
+  } %>
+  <%= form_for review, url: review.new_record? ? post_products_path(widget_id: widget.id) : review_path(review, widget_id: widget.id, group: @group_by),
+      html: {
+        multipart: true,
+        autocomplete: 'off',
+        class: 'form_review',
+        method: review.new_record? ? 'post' : 'patch'
+      },
+      remote: true,
+      validate: true,
+      data: {
+        login_required: !@brand.review_enable_nonmember_review?,
+        review_message_default: @brand.review_message_default,
+        already_posted: review.duplicate? ? t('reviews.form.already_posted') : nil,
+        alert_requirement: @brand.review_alert_mileage_requirement_before_submit,
+        disable_save_requirement: @brand.disable_review_with_insufficient_review_length,
+        not_creatable_reason: (review_not_creatable_reason(product) if review.new_record?)
+      } do |f| %>
+    <%= hidden_field_tag :thumbnail_summary, params[:thumbnail_summary] %>
+    <div class="form_review__message_field limit-count-container">
+      <%= render 'reviews/review_option_fields', f: f %>
+      <%= f.text_area(
+        :message,
+        class: "form_review__textarea input-block autogrow count-limit #{review.new_record? ? 'new-review-form' : 'edit-review-form'}",
+        placeholder: (@brand.review_message_placeholder if @brand.review_default_message_type == ReviewDefaultMessageType::PLACEHOLDER),
+        maxlength: Settings.max_review_length,
+        col: 5,
+        cols: 5000, # HACK - IE8 textarea scroll bug
+        data: {
+          login_required: !@brand.review_enable_nonmember_review?,
+          up_counter: true,
+          minimum_message_length: @brand.min_review_length_to_get_mileage,
+          minimum_message_length_warning: t('reviews.form.minimum_message_length_warning', length: @brand.min_review_length_to_get_mileage),
+          minimum_message_length_error: t('reviews.form.minimum_message_length_error', length: @brand.min_review_length_to_get_mileage)
+        }) %>
+      <div class='limit-counter'>0</div>
+      <div class="review-input-photos form_review__input_photos">
+        <div class="input-button review-photos">
+          <%= render 'common/reviews/image_fields', review: review, f: f %>
+        </div>
+      </div>
+    </div>
+    <div class="form_review__input_area_container">
+      <div class="form_review__add_image_container field-box add-image-container">
+        <%= content_tag :div, '이미지 업로드', class: 'form_review__add_image_description', data: {org_text: t('products.reviews.add_photo')} %>
+      </div>
+      <div class="form_review__field_box_continer">
+        <div class="form_review__score_container">
+          <%= f.select :score, ReviewScore.values.collect {|score| [ReviewScore.t(score), score]}, {}, {class: 'select-rating'} %>
+        </div>
+      </div>
+      <%= f.hidden_field :product_id %>
+      <%= f.hidden_field :review_source %>
+      <%= f.hidden_field :sub_order_id %>
+      <%= f.hidden_field :position %>
+      <%= content_tag :button, class: 'form_review__submit hoverable', type: 'submit', data: {disable_with: t('saving')} do %>
+        <span>
+          <%= review.new_record? ? t('reviews.post_review') : t('reviews.edit_review') %>
+        </span>
+      <% end %>
+    </div>
+    <script type="text/x-jquery-tmpl" class="new-image-field">
+      <%= render('common/reviews/image_field', f: f, template: true, review: review) %>
+    </script>
+  <% end %>
+</div>

--- a/views/pc/reviews/_review_content_expanded.html.erb
+++ b/views/pc/reviews/_review_content_expanded.html.erb
@@ -1,0 +1,20 @@
+<%= content_tag(:div, t('products.reviews.my_last_review', user: review.user_display_name), class: 'my-first-review') if local_assigns[:is_my_last_review] %>
+<div class="panel-body no-border">
+  <%= render 'reviews/review_options', review: review, klass: 'review-options--oneline products_reviews_list_review__review_options' %>
+  <%= render 'reviews/message', review: review %>
+  <%= render 'reviews/images', review: review, li_class: 'grid-4 review_expanded__thumbnail', ul_class: 'images review_expanded__thumbnails_container' %>
+</div>
+<div class="panel-footer no-border">
+  <div class="products_reviews_list_review__actions_container">
+    <div class="inline" style="display: none;">
+      <a class="mall-link-color comments-link link-collapse"><%= t('reviews.close_expanded_review') %></a>
+    </div>
+    <%= render 'reviews/action_likes', review: review %>
+  </div>
+  <%= render 'reviews/comments', review: review %>
+  <div class="products_reviews_list_review__collapse">
+    <a class="link-collapse">
+      <div class="products_reviews_list_review__collapse_button">▲</div>
+    </a>
+  </div>
+</div>

--- a/views/pc/reviews/_review_footer.html.erb
+++ b/views/pc/reviews/_review_footer.html.erb
@@ -1,0 +1,15 @@
+<div class="panel-footer no-border">
+  <div class="products_reviews_list_review__actions_container">
+    <div class="inline" style="display: none;">
+      <%= content_tag :a, class: "mall-link-color comments-link #{'link-expand' if !show_comments}" do %>
+        <% if review.comments_count == 0 %>
+          <%= @brand.review_enable_user_comments ? t('reviews.comments.please_write_comments'): t('reviews.comments.no_comments_yet') %>
+        <% else %>
+          <%= t('reviews.comments.comments_count_html', count: review.comments_count) %>
+        <% end %>
+      <% end %>
+    </div>
+    <%= render 'reviews/action_likes', review: review %>
+  </div>
+  <%= render 'reviews/comments', review: review if show_comments %>
+</div>

--- a/views/pc/reviews/_review_option_fields.html.erb
+++ b/views/pc/reviews/_review_option_fields.html.erb
@@ -1,0 +1,45 @@
+<% review_option_types = brand.visible_options %>
+<% if !review_option_types.empty? %>
+  <% review = f.object %>
+  <div class="form_review__review_option_fields">
+    <% review_option_types.each_with_index do |option_type, i| %>
+      <% option = review.option(option_type.id) %>
+      <%= f.fields_for :options, option do |r| %>
+        <%= content_tag :div, class: "form_review__review_option_field #{'first' if i == 0}" do %>
+          <%= r.hidden_field :review_option_type_id %>
+          <%= content_tag :div, class: 'form_review__review_option_field_title', title: option_type.name do %>
+            <%= option_type.name %> <%= "(#{option_type.unit})" if option_type.field_type == ReviewOptionFieldType::NUMBER && !option_type.unit.blank? %> <%= '*' if option_type.required %> :
+          <% end %>
+          <div class="form_review__review_option_field_content">
+            <% case option_type.field_type %>
+            <% when ReviewOptionFieldType::NUMBER %>
+              <%= r.text_field :value, class: "form_review__review_option_field_value form_review__review_option_field_value--number #{'required' if option_type.required}", data: {message: option_type.validate_message}, validate: false %>
+            <% when ReviewOptionFieldType::SELECT %>
+              <% if option_type.options %>
+                <%= r.select :value, option_type.option_values.split(',').collect {|o| [o, o]}, {include_blank: ''}, class: "form_review__review_option_field_value select2 #{'required' if option_type.required}", data: {message: option_type.validate_message}, validate: false %>
+              <% else %>
+                <%= r.text_field :value, class: "form_review__review_option_field_value #{'required' if option_type.required}", data: {message: option_type.validate_message}, validate: false %>
+              <% end %>
+            <% else %>
+              <%= r.text_field :value, class: "form_review__review_option_field_value #{'required' if option_type.required}", data: {message: option_type.validate_message}, validate: false %>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
+    <% if review.sub_order && review.sub_order.product_options.present? %>
+      <div class="product_options">
+        <div class="product_options__title"><%= t('review_options.title') %></div>
+        <div class="product_options__contents">
+          <% review.sub_order.product_options.each do |key, value| %>
+            <div class="product_options__content">
+              <span class='product_options__key'><%= key %>:</span>
+              <span class='product_options__value'><%= value %></span>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+    <%= content_tag(:div, nil, class: 'divider') if local_assigns[:divider] %>
+  </div>
+<% end %>


### PR DESCRIPTION
### 작업 내용
- 리뷰 개수, 평점 내용 추가
- 포토리뷰 썸네일이 주기적으로 롤링되고, 좌우 화살표로 스크롤 되는 기능 구현
- 리뷰 작성 폼 레이아웃 수정
  - 추가입력 양식 한줄에 나오도록 수정
  - placeholder 여러줄로 나오도록 수정
  - 이미지 업로드 버튼 CSS 수정
  - 평점 레이아웃 변경
  - 등록 버튼 CSS 수정
- 추가정보 양식 필터가 기본적으로 나오도록 레이아웃 수정
- 소팅에 리뷰 개수 나오는 것 제거
- 리뷰 작성자 정보 영역 CSS 수정
- 리뷰 좋아요 정보 아이콘과 텍스트 위치 변경
- 리뷰 본문 내용 폰트 사이즈 조정
- 좋아요/댓글 영역 레이아웃 수정
- 댓글 작성일 추가
- 댓글 CSS 수정
- 댓글 작성 버튼 CSS 수정
- 리뷰 하단에 펼침을 닫는 버튼 추가하고 기존에 닫기는 제거

https://app.asana.com/0/6477641678483/328195358679419