### PR TITLE
FIX - 상품 상세페이지 상단 평점 위젯에 리뷰 수 제대로 안나오는 문제 수정

### DIFF
--- a/views/pc/products/reviews/_photo_thumbnail.html.erb
+++ b/views/pc/products/reviews/_photo_thumbnail.html.erb
@@ -11,7 +11,7 @@
         <%= widget.title.html_safe %>
       </div>
       <div class="products_reviews_photo_thumbnail__summary">
-        <span>전체 리뷰 <strong class="products_reviews_photo_thumbnail__value"><%= number_with_delimiter(product.meta_visible_reviews.count) %></strong>개</span>
+        <span>전체 리뷰 <strong class="products_reviews_photo_thumbnail__value"><%= number_with_delimiter(product.meta_reviews_count) %></strong>개</span>
         <span class="products_reviews_photo_thumbnail__divider">|</span>
         <span>포토 리뷰 <strong class="products_reviews_photo_thumbnail__value"><%= number_with_delimiter(product.meta_visible_reviews.with_photo.count) %></strong>개</span>
         <span class="products_reviews_photo_thumbnail__divider">|</span>

--- a/views/pc/products/reviews/_photo_thumbnail.html.erb
+++ b/views/pc/products/reviews/_photo_thumbnail.html.erb
@@ -11,9 +11,9 @@
         <%= widget.title.html_safe %>
       </div>
       <div class="products_reviews_photo_thumbnail__summary">
-        <span>전체 리뷰 <strong class="products_reviews_photo_thumbnail__value"><%= number_with_delimiter(product.reviews_count) %></strong>개</span>
+        <span>전체 리뷰 <strong class="products_reviews_photo_thumbnail__value"><%= number_with_delimiter(product.meta_visible_reviews.count) %></strong>개</span>
         <span class="products_reviews_photo_thumbnail__divider">|</span>
-        <span>포토 리뷰 <strong class="products_reviews_photo_thumbnail__value"><%= number_with_delimiter(product.photo_reviews_count) %></strong>개</span>
+        <span>포토 리뷰 <strong class="products_reviews_photo_thumbnail__value"><%= number_with_delimiter(product.meta_visible_reviews.with_photo.count) %></strong>개</span>
         <span class="products_reviews_photo_thumbnail__divider">|</span>
         <span>고객 만족도 <strong class="products_reviews_photo_thumbnail__value"><%= product.display_score %></strong></span>
       </div>


### PR DESCRIPTION
### 원인
- 리뷰수/포토리뷰수에 셋트상품의 리뷰가 포함되지 않았음. 코드상에서 상품의 reviews_count를 노출하고 있었음

### 해결
- #meta_visible_reviews를 활용하도록 수정

https://app.asana.com/0/387756544328546/387756544328546